### PR TITLE
Improved output and sinkhole/hosts format

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Setting a `--line-prefix` can be used to generate a `hosts` formatted list.
 python generate_lists.py \
     --input-directory my-tracker/domains \
     --output-pathname /path/to/my-output.txt \
-    --line-prefix '127.0.0.1 ' \
+    --destination-address '127.0.0.1' \
     --exclude-uncategorized \
     --exclude-category CDN \
     --exclude-category 'Embedded Content' \

--- a/generate_list.py
+++ b/generate_list.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import datetime
 
 
 INTRO_TEXT = """
@@ -86,6 +87,13 @@ def main():
 
     output_file = open(args.output_pathname, "w")
     output_file.write(INTRO_TEXT)
+    stamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    output_file.write(f"# Blocklist generated: {stamp}\n#\n")
+    output_file.write(f"# Exclude categories:\n")
+    for category in excluded_categories:
+        output_file.write(f"# - {category}\n")
+        continue
+    output_file.write(f"#\n# Exclude uncategorized:\n# - {args.exclude_uncategorized}\n\n")
 
     file_list = os.scandir(args.input_directory)
 

--- a/generate_list.py
+++ b/generate_list.py
@@ -55,8 +55,8 @@ def parse_args():
         default="phased_array_blocklist.txt"
     )
     parser.add_argument(
-        "--line-prefix", "-l",
-        help="Prefix for each entry in the output file",
+        "--destination-address", "-d",
+        help="Sinkhole destination address (sets output in hosts file format)",
         default="",
     )
     parser.add_argument(
@@ -84,6 +84,7 @@ def main():
         args.exclude_categories or
         DEFAULT_EXCLUDED_CATEGORIES
     )
+    line_prefix = args.destination_address + "\t" if len(args.destination_address) > 0 else ""
 
     output_file = open(args.output_pathname, "w")
     output_file.write(INTRO_TEXT)
@@ -112,7 +113,7 @@ def main():
             continue
         domains_included += 1
         print(f"Adding: {domain}")
-        output_file.write(f"{args.line_prefix}{domain}\n")
+        output_file.write(f"{line_prefix}{domain}\n")
 
     file_list.close()
     output_file.close()

--- a/phased_array_blocklist.txt
+++ b/phased_array_blocklist.txt
@@ -21,6 +21,19 @@
 #
 #  - https://pi-hole.net
 
+# Blocklist generated: 2020-03-12 11:17:16
+#
+# Exclude categories:
+# - Online Payment
+# - Non-tracking
+# - CDN
+# - SSO
+# - Embedded Content
+# - Federated Login
+#
+# Exclude uncategorized:
+# - True
+
 abtasty.com
 adstanding.com
 tns-counter.ru


### PR DESCRIPTION
Configuration options now included in output metadata.
--line-prefix removed in favour of --destination-address.

Specifying a --destination-address will output a 'hosts' file format (e.g. 127.0.0.1  baddomain.com). 
The input is automatically tabbed to improve human readability of the output.